### PR TITLE
Fix array checking in `getQuerySelector()`

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -19,7 +19,7 @@ import { getCommonAncestor, getCommonProperties } from './common'
  * @return {string}                                  - [description]
  */
 export default function getQuerySelector (input, options = {}) {
-  if (!input.length) {
+  if (input.constructor !== Array) {
     return getSingleSelector(input, options)
   }
   return getMultiSelector(input, options)


### PR DESCRIPTION
First off, massive kudos for your work on this library! I did find a rather sneaky bug outlined below.

Property existance checking is insufficient for determining the type of a variable and actually led to a bug in this case: `<select>` elements have a `length` property denoting the number of contained `<option>` elements; `optimal-select` would treat this element as an array, causing it to fail.