### PR TITLE
remove console.warn from match.js

### DIFF
--- a/src/match.js
+++ b/src/match.js
@@ -233,9 +233,7 @@ function checkChilds (priority, element, ignore, path) {
     if (child === element) {
       const childPattern = findPattern(priority, child, ignore)
       if (!childPattern) {
-        return console.warn(`
-          Element couldn\'t be matched through strict ignore pattern!
-        `, child, ignore, childPattern)
+        return false
       }
       const pattern = `> ${childPattern}:nth-child(${i+1})`
       path.unshift(pattern)


### PR DESCRIPTION
This library currently sends a warning to the console, which is not ideal in production. This PR removes that warning.