### PR TITLE
fixes issue #58: `getSingleSelector` throws error if the `root` is a shadow DOM root

### DIFF
--- a/src/match.js
+++ b/src/match.js
@@ -190,7 +190,10 @@ function findAttributesPattern (priority, element, ignore) {
 function checkTag (element, ignore, path, parent = element.parentNode) {
   const pattern = findTagPattern(element, ignore)
   if (pattern) {
-    const matches = parent.getElementsByTagName(pattern)
+    const matches = parent.getElementsByTagName
+      ? parent.getElementsByTagName(pattern)
+      : parent.querySelectorAll(pattern);
+    
     if (matches.length === 1) {
       path.unshift(pattern)
       return true


### PR DESCRIPTION
This PR modifies `checkTag` function of `match.js` which calls getElementsByTagName method against `element.parentNode` even if the element doesn't have the method. So when the parent is a shadowRoot that doesn't have `getElementsByTagName` it throws an error. So this PR modifies the function so that it calls querySelectorAll when getElementsByTagName isn't available.