### PR TITLE
Fixes invalid `module` field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "license": "MIT",
   "main": "lib/index.js",
-  "module": "src/index.js",
+  "module": "lib/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/Autarc/optimal-select.git"


### PR DESCRIPTION
`module` referred to `src/index.js`, which does not exist. Point to `lib/index.js` instead.

Without fixing this, tools like rollup would give an error when trying to include as part of
a bundle. Alternatively, could probably just remove the `module` field entirely (since it is
the same as `main` in this case)